### PR TITLE
ENH: Adding the Paraview TimeHandler protocol

### DIFF
--- a/pvw/server/pv_server_statefile.py
+++ b/pvw/server/pv_server_statefile.py
@@ -54,6 +54,7 @@ class _DemoServer(pv_wslink.PVServerProtocol):
         # Bring used components
         self.registerVtkWebProtocol(pv_protocols.ParaViewWebMouseHandler())
         self.registerVtkWebProtocol(pv_protocols.ParaViewWebViewPort())
+        self.registerVtkWebProtocol(pv_protocols.ParaViewWebTimeHandler())
         self.registerVtkWebProtocol(
             pv_protocols.ParaViewWebPublishImageDelivery(decode=False))
         self.updateSecret(_DemoServer.authKey)


### PR DESCRIPTION
Just uses the base one that ParaviewWeb already provides. Here are the options and controls you can hit from the js side.
(More options listed on the webpage here: https://kitware.github.io/paraviewweb/api/IO_WebSocket_ParaViewWebClient.html)

```js
/* eslint-disable arrow-body-style */
export default function createMethods(session) {
  return {
    updateTime: (action) => {
      return session.call('pv.vcr.action', [action]);
    },
    next: () => {
      return session.call('pv.vcr.action', ['next']);
    },
    previous: () => {
      return session.call('pv.vcr.action', ['prev']);
    },
    first: () => {
      return session.call('pv.vcr.action', ['first']);
    },
    last: () => {
      return session.call('pv.vcr.action', ['last']);
    },

    setTimeStep: (idx) => {
      return session.call('pv.time.index.set', [idx]);
    },

    getTimeStep: () => {
      return session.call('pv.time.index.get', []);
    },

    setTimeValue: (t) => {
      return session.call('pv.time.value.set', [t]);
    },

    getTimeValue: () => {
      return session.call('pv.time.value.get', []);
    },

    getTimeValues: () => {
      return session.call('pv.time.values', []);
    },

    play: (deltaT = 0.1) => {
      return session.call('pv.time.play', [deltaT]);
    },

    stop: () => {
      return session.call('pv.time.stop', []);
    },
  };
}
```