### PR TITLE
MNT: Clarify running the application locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 docker/binaries/
 .vscode
 data/
+pv-ready-data*
 pvw/www/swt
 pvw/launcher/log/*.txt
 pvw/launcher/log/*.log


### PR DESCRIPTION
This updates the testing procedure locally to use the container instead of needing to spin up and install Paraview.

This enables us to test the frontend locally. You'll need to update the `environments/environment.ts` file in the frontend repository like this for now (until I discuss with frontend team how to best add that over there).
![image](https://user-images.githubusercontent.com/12417828/151060357-4fae4e77-0f8c-43d2-a508-ad4113b8edbc.png)

I'd suggest just going through the steps as I've outlined here to try and get it to work and let me know if you run into any errors along the way.