### PR TITLE
Add MPI launch config

### DIFF
--- a/pvw/launcher/config.json
+++ b/pvw/launcher/config.json
@@ -15,7 +15,9 @@
   },
   "properties": {
     "dataDir": "/data",
-    "python_exec": "/opt/paraview/bin/pvpython"
+    "python_exec": "/opt/paraview/bin/pvpython",
+    "mpi_run": "/opt/paraview/bin/mpiexec",
+    "batch_exec": "/opt/paraview/bin/pvbatch"
   },
   "apps": {
     "visualizer": {
@@ -30,7 +32,22 @@
         "--viewport-max-height", "1080",
         "--timeout", "30"
       ],
-      "ready_line" : "Starting factory"
+      "ready_line" : "Starting h3lioviz factory"
+    },
+    "visualizer-mpi": {
+      "cmd": ["env", "PARAVIEW_LOG_EXECUTION_VERBOSITY=INFO",
+        "env", "PARAVIEW_LOG_RENDERING_VERBOSITY=INFO",
+        "${mpi_run}", "-np", "4",
+        "${batch_exec}",
+        EXTRA_PVPYTHON_ARGS
+        "/pvw/server/app_server.py",
+        "--port", "${port}",
+        "--dir", "/data",
+        "--viewport-max-width", "1920",
+        "--viewport-max-height", "1080",
+        "--timeout", "30"
+      ],
+      "ready_line" : "Starting MPI h3lioviz factory"
     }
   }
 }

--- a/pvw/launcher/config.json
+++ b/pvw/launcher/config.json
@@ -32,7 +32,7 @@
         "--viewport-max-height", "1080",
         "--timeout", "30"
       ],
-      "ready_line" : "Starting h3lioviz factory"
+      "ready_line" : "Starting factory"
     },
     "visualizer-mpi": {
       "cmd": ["env", "PARAVIEW_LOG_EXECUTION_VERBOSITY=INFO",
@@ -47,7 +47,7 @@
         "--viewport-max-height", "1080",
         "--timeout", "30"
       ],
-      "ready_line" : "Starting MPI h3lioviz factory"
+      "ready_line" : "Starting factory"
     }
   }
 }


### PR DESCRIPTION
This adds an optional extra app that will launch the visualizer in MPI mode, making switching between serial and parallel much easier. Defaults to 4 processors for now, but we could update this at some point too.

To use it you'd change the `application` in the environment file on the frontend to "visualizer-mpi"