### PR TITLE
FIX: Update evolution data rather than creating new objects

### DIFF
--- a/pvw/server/satellite.py
+++ b/pvw/server/satellite.py
@@ -69,6 +69,20 @@ class Satellite:
         self.label_disp.BillboardPosition = [x + size for x in self.sat.Center]
         self.label_disp.Color = [0, 0, 0]  # Black text
 
+    def change_evolution_file(self, fname):
+        """Change the underlying evolution file
+
+        This adds the ability to change the data file of the
+        satellite without recreating all of the underlying objects.
+
+        Parameters
+        ----------
+
+        fname : Path
+            Path of the evolution data file for this satellite
+        """
+        self.evolution = Evolution(fname)
+
     def add_fieldline(self, data):
         """
         Add a fieldline trace to this satellite.


### PR DESCRIPTION
This changes the underlying evolution file data for the satellites
when a model run is changed rather than creating new satellites
which could cause double images to be rendered.

To test locally, pull down this branch, then run the docker container with `-v ${PWD}/pvw:/pvw` pointing to the proper `/pvw` location on your local system.