### PR TITLE
Added Br to evo

### DIFF
--- a/scripts/process_output.py
+++ b/scripts/process_output.py
@@ -158,6 +158,7 @@ def process_evo(ds):
     ds["Bx"], ds["By"], ds["Bz"] = spherical_to_cartesian(
         ds["X1"], ds["X2"], ds["X3"], ds["B1"], ds["B2"], ds["B3"]
     )
+    ds["Br"] = ds["B1"]
 
     # ds['Vx'], ds['Vy'], ds['Vz'] =
     # spherical_to_cartesian(ds['n1'], ds['n2'], ds['n3'],
@@ -441,19 +442,19 @@ def main():
     parser.add_argument(
         "--radius-downsample",
         type=int,
-        default=1,
+        default=8,
         help="Downsample the radius dimension by this factor. Default is 1 (no downsampling).",
     )
     parser.add_argument(
         "--longitude-downsample",
         type=int,
-        default=1,
+        default=2,
         help="Downsample the longitude dimension by this factor. Default is 1 (no downsampling).",
     )
     parser.add_argument(
         "--latitude-downsample",
         type=int,
-        default=1,
+        default=2,
         help="Downsample the latitude dimension by this factor. Default is 1 (no downsampling).",
     )
     parser.add_argument(


### PR DESCRIPTION
I updated the default downsampling values for the process_output.py script to be what we settled on in the cdk

I tested this by processing a run and checking the 'data_vars' field for 'Br' in the evo*.json files. I think there may need to be a frontend update to the charts in order to use the new field in the evo files. 