### PR TITLE
Fixed run switch

### DIFF
--- a/pvw/server/app.py
+++ b/pvw/server/app.py
@@ -56,7 +56,7 @@ OPACITY_VALUES = {
 DEFAULT_CMAP = {
     "velocity": "WSA-Enlil",
     "density": "WSA-Enlil",
-    "pressure": "Viridis (matplotlib)",
+    "pressure": "WSA-Enlil",
     "temperature": "Inferno (matplotlib)",
     "b": "Cool to Warm",
     "bx": "Cool to Warm",
@@ -174,11 +174,6 @@ class App(pv_protocols.ParaViewWebProtocol):
             # Force an update and re-render
             self.model.data.UpdatePipeline()
             pvs.Render(self.view)
-            if max(self.get_variable_range("pressure")) > 1e4:
-                self._old_pressure_units = True
-            else:
-                self._old_pressure_units = False
-            return
 
         # We are in initialization and don't have a model yet, so
         # we need to create one


### PR DESCRIPTION
This PR fixes the bug where h3lioviz crashes when switching runs. There seems to be weird artifacting on the timestamp on the top-left corner now, and I'm not sure if that was present before. It only appears after switching runs, so I can't test whether or not it happens with the currently deployed code.

There is a ticket open to fix the clock issue: [DB-3354](https://jira.lasp.colorado.edu/browse/DB-3354)