### PR TITLE
Added Space Check for OTF Downloads

### DIFF
--- a/pvw/server/app.py
+++ b/pvw/server/app.py
@@ -4,6 +4,7 @@ import math
 import pathlib
 import os
 import subprocess
+import shutil
 
 import paraview.simple as pvs
 from paraview.web import protocols as pv_protocols
@@ -14,7 +15,6 @@ import paraview.web.venv
 import models
 import satellite
 import slice
-import shutil
 
 
 # TODO: Try and use faster plugins where possible


### PR DESCRIPTION
# Testing instructions:

Change STORAGE_SPACE_CUTOFF_GB in pvw/app.py to something high like 150.

# Example Error message

<img width="1223" height="67" alt="image" src="https://github.com/user-attachments/assets/69e65d94-2f62-418b-a87f-d6fb5ff69976" />
