### PR TITLE
Multi-stage builds for frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ COPY --from=frontend-builder /tmp/h3lioviz/h3lioviz-main/dist/h3lioviz /pvw/www/
 
 FROM base AS frontend-false
 
-FROM frontend-${BUILD_FRONTEND} as final 
+FROM frontend-${BUILD_FRONTEND} AS final 
 
 # Start the container.  If we're not running this container, but rather are
 # building other containers based on it, this entry point can/should be

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,36 @@ ARG BASE_IMAGE=ubuntu:20.04
 # Setting the below argument to false disables installing AWS packages
 ARG AWS_ENABLED=false
 
+# ============================================================================
+# Frontend builder stage - builds h3lioviz in a Node.js container
+# This stage only rebuilds when the h3lioviz repository changes
+# ============================================================================
+FROM node:22-slim AS frontend-builder
+
+ARG FRONTEND_ENVIRONMENT="dev"
+ARG H3LIOVIZ_VERSION=main
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        unzip \
+        ca-certificates && \
+        rm -rf /var/lib/apt/lists/*
+
+# Download and build h3lioviz
+# The H3LIOVIZ_VERSION arg can be used to bust cache when the repo changes
+RUN curl -L "https://github.com/SWxTREC/h3lioviz/archive/refs/heads/${H3LIOVIZ_VERSION}.zip" -o /tmp/h3lioviz.zip && \
+    unzip /tmp/h3lioviz.zip -d /tmp/h3lioviz && \
+    rm -rf /tmp/h3lioviz.zip
+
+WORKDIR /tmp/h3lioviz/h3lioviz-${H3LIOVIZ_VERSION}
+
+RUN npm install --prefer-offline --no-audit --progress=false && \
+    npm rebuild esbuild && \
+    npm run build:${FRONTEND_ENVIRONMENT}
+
+# ============================================================================
+# Main application stage
+# ============================================================================
 # ARG BASE_IMAGE=nvidia/opengl:1.0-glvnd-devel-ubuntu20.04
 FROM ${BASE_IMAGE} AS base
 
@@ -31,11 +61,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3.9-venv \
         git && \
         rm -rf /var/lib/apt/lists/*
-
-# Instructions for installing node for  https://deb.nodesource.com
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-RUN apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
 
 RUN curl -L "https://github.com/peak/s5cmd/releases/download/v2.1.0/s5cmd_2.1.0_Linux-64bit.tar.gz" -o /tmp/s5cmd.tar.gz && \ 
     tar -xvzf /tmp/s5cmd.tar.gz -C /usr/local/bin && \
@@ -98,21 +123,9 @@ COPY pvw /pvw
 
 RUN mkdir /data
 
-# NOTE: Having the frontend build 
-RUN if [ ! -d "/pvw/www/h3lioviz" ]; then \
-    curl -L "https://github.com/SWxTREC/h3lioviz/archive/refs/heads/main.zip" -o /tmp/h3lioviz.zip && \
-    unzip /tmp/h3lioviz.zip -d /tmp/h3lioviz && \
-    rm -rf h3lioviz.zip && \
-    cd /tmp/h3lioviz/h3lioviz-main && \
-    npm install --prefer-offline --no-audit --progress=false && \
-    npm rebuild esbuild && \
-    npm run build:${FRONTEND_ENVIRONMENT} && \
-    cp -r dist/h3lioviz /pvw/www/h3lioviz && \
-    cd / && \
-    rm -rf /tmp/h3lioviz/; \
-else \
-    echo "pvw/www/h3lioviz found. Skipping frontend h3lioviz build."; \
-fi
+# Copy the built frontend from the builder stage
+# This only rebuilds when the frontend-builder stage changes
+COPY --from=frontend-builder /tmp/h3lioviz/h3lioviz-main/dist/h3lioviz /pvw/www/h3lioviz
 
 # Start the container.  If we're not running this container, but rather are
 # building other containers based on it, this entry point can/should be

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=ubuntu:20.04
 # Setting the below argument to false disables installing AWS packages
 ARG AWS_ENABLED=false
+ARG BUILD_FRONTEND=true
 
 # ============================================================================
 # Frontend builder stage - builds h3lioviz in a Node.js container
@@ -16,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         ca-certificates && \
         rm -rf /var/lib/apt/lists/*
+
 
 # Download and build h3lioviz
 # The H3LIOVIZ_VERSION arg can be used to bust cache when the repo changes
@@ -125,7 +127,12 @@ RUN mkdir /data
 
 # Copy the built frontend from the builder stage
 # This only rebuilds when the frontend-builder stage changes
+FROM base AS frontend-true
 COPY --from=frontend-builder /tmp/h3lioviz/h3lioviz-main/dist/h3lioviz /pvw/www/h3lioviz
+
+FROM base AS frontend-false
+
+FROM frontend-${BUILD_FRONTEND} as final 
 
 # Start the container.  If we're not running this container, but rather are
 # building other containers based on it, this entry point can/should be

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG BUILD_FRONTEND=true
 # ============================================================================
 # Frontend builder stage - builds h3lioviz in a Node.js container
 # This stage only rebuilds when the h3lioviz repository changes
+# and the BUILD_FRONTEND arg is set to true
 # ============================================================================
 FROM node:22-slim AS frontend-builder
 

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ To work with this repository, you will need:
 ## Building the Docker Image
 
 [!NOTE]
-The Dockerfile now includes steps to build the frontend. You can build the image with an included environment file by selecting one of the currently supported options (`dev`, `prod`, or `swpc`) via a Docker build argument (default is `dev` if unspecified). Other environments (for example, a future `noaa` option) are not yet available.
+The Dockerfile now includes steps to build the frontend. You can build the image with an included environment file by selecting one of the currently supported options (`dev`, `prod`, or `swpc`) via a Docker build argument (default is `dev` if unspecified). Other environments (for example, a future `noaa` option) are not yet available. The `--build-arg BUILD_FRONTEND` is optional since this argument defaults to true. 
 
 Build the image locally:
 
 ```bash
-docker build --build-arg FRONTEND_ENVIRONMENT=prod .
+docker build --build-arg FRONTEND_ENVIRONMENT=prod --build-arg BUILD_FRONTEND=true .
 ```
 
 For advanced usage and to build a different version of the frontend locally, you can
@@ -133,10 +133,10 @@ cp -r {frontend-path}/dist/* pvw/www
 
 ### Step 7: Build the Docker Image
 
-Build the image locally:
+Build the image locally using a pre-built frontend:
 
 ```bash
-docker build -t h3lioviz .
+docker build --build-arg BUILD_FRONTEND=false -t h3lioviz .
 ```
 
 ## Deployment


### PR DESCRIPTION
Separating this out from #94 as this is really a separate update.

This has the frontend build in a separate build layer so that it is cached separately and doesn't impact any other steps and gets built in parallel too. Maybe we should do the same for the Paraview binary portion in a follow-up.