### PR TITLE
Process NASA Helioweb Objects to Enable Visualization of Inner Planets 

### DIFF
--- a/scripts/process_helioweb.py
+++ b/scripts/process_helioweb.py
@@ -8,7 +8,13 @@ import requests
 import xarray as xr
 
 # Converts names of objects to the codes needed ot request position data from NASA HELIOWeb
-HELIOWEB_OBJECT_CODES = {"earth": "04", "mars": "42", "venus": "15", "mercury": "29"}
+HELIOWEB_OBJECT_CODES = {
+    "earth": "04",
+    "mars": "42",
+    "venus": "15",
+    "mercury": "29",
+    "solar_orbiter": "46",
+}
 J2000_JD = 2451545.0
 # Number of days in a julian century
 JULIAN_CENTURY_DAYS = 36525.0
@@ -126,6 +132,7 @@ def download_helioweb_hgi(object_name: str, start_date: datetime, end_date: date
             print(
                 f"Warning: malformed line in downloaded HELIOWeb data for {object_name}. See above output for details. Continuing..."
             )
+            continue
 
         rows.append(tuple(cols))
 

--- a/scripts/process_helioweb.py
+++ b/scripts/process_helioweb.py
@@ -7,7 +7,7 @@ import numpy as np
 import requests
 import xarray as xr
 
-# Converts names of objects to the codes needed ot request position data from NASA HELIOWeb
+# Converts names of objects to the codes needed to request position data from NASA HELIOWeb
 HELIOWEB_OBJECT_CODES = {
     "earth": "04",
     "mars": "42",
@@ -104,7 +104,7 @@ def download_helioweb_hgi(object_name: str, start_date: datetime, end_date: date
 
     # Get the data from HELIOWeb
     response = requests.post(
-        "https://omniweb.gsfc.nasa.gov/cgi/models/helios2_h.cgi", data=query
+        "https://omniweb.gsfc.nasa.gov/cgi/models/helios2_h.cgi", data=query, timeout=30
     )
     # Raises an error on any non 2XX status code
     response.raise_for_status()
@@ -294,7 +294,7 @@ def hnm_to_paraview(year, day_of_year, hour, r, colat, lon):
     times = np.array(
         [
             (
-                datetime(int(year), 1, 1)
+                datetime(int(year), 1, 1, tzinfo=timezone.utc)
                 + timedelta(days=int(day) - 1, hours=int(hour))
             ).timestamp()
             for year, day, hour in zip(year, day_of_year, hour)

--- a/scripts/process_helioweb.py
+++ b/scripts/process_helioweb.py
@@ -1,0 +1,351 @@
+import json
+import pathlib
+import re
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import requests
+import xarray as xr
+
+# Converts names of objects to the codes needed ot request position data from NASA HELIOWeb
+HELIOWEB_OBJECT_CODES = {"earth": "04", "mars": "42", "venus": "15", "mercury": "29"}
+J2000_JD = 2451545.0
+# Number of days in a julian century
+JULIAN_CENTURY_DAYS = 36525.0
+
+
+def process_helioweb(
+    satellite_list: list[str],
+    start_date: datetime,
+    end_date: datetime,
+    newpath: pathlib.Path,
+):
+    for satellite in satellite_list:
+        # Download NASA helioweb data for each satellite
+        hgi_data = download_helioweb_hgi(satellite, start_date, end_date)
+
+        # Convert from NASA helioweb's coordinates, HGI,
+        # to the system used by ENLIL, HNM (HEEQ+180).
+        hnm_data = hgi_to_hnm_from_date(
+            hgi_data["year"],
+            hgi_data["day"],
+            hgi_data["hour"],
+            hgi_data["radius_au"],
+            hgi_data["hgi_lat"],
+            hgi_data["hgi_lon"],
+        )
+
+        # Convert from ENLIL's HNM to what paraview expects.
+        # This means converting from spherical to cartesian
+        # as well as setting up time as seconds since 1970-01-01
+        pv_data = hnm_to_paraview(
+            hnm_data["year"],
+            hnm_data["day"],
+            hnm_data["hour"],
+            hnm_data["radius_au"],
+            hnm_data["colattitude_rad"],
+            hnm_data["longitude_rad"],
+        )
+
+        # Build the processed xr.Dataset that will be converted
+        # to both a netCDF file # and json file for use by paraview.
+        # All of the variables besides X, Y, Z, and time are set to NaN
+        ds = build_pv_evo_dataset(
+            pv_data["X"], pv_data["Y"], pv_data["Z"], pv_data["time"]
+        )
+
+        # TODO we could probably have a shared "save_evo()" function for both helioweb
+        # and normal ENLIL evo.
+        # Copied from the evo logic in process_directory()
+        newfile = newpath / f"evo.{satellite}.nc"
+        ds.to_netcdf(newfile)
+
+        newds = xr.load_dataset(newfile, decode_times=False)
+
+        json_file = pathlib.Path(str(newfile).replace(".nc", ".json"))
+        with open(json_file, "w") as f:
+            f.write(
+                json.dumps(
+                    json.loads(
+                        json.dumps(newds.to_dict()),
+                        parse_float=lambda x: round(float(x), 3),
+                    )
+                )
+            )
+
+
+def download_helioweb_hgi(object_name: str, start_date: datetime, end_date: datetime):
+    """
+    Download hourly HGI coordinates from NASA HELIOWeb for a given object
+    Web GUI: https://omniweb.gsfc.nasa.gov/coho/helios/heli.html
+    """
+    query = {
+        "activity": "retrieve",
+        "object": HELIOWEB_OBJECT_CODES[object_name],
+        # This cooresponds to the HGI coordinate system
+        "coordinate": "3",
+        "resolution": "Hourly",
+        # Number of decimal places for radius (needs verification maybe it applies to lat/lon as well
+        "precn": "4",
+        "start_year": start_date.year,
+        "start_day": start_date.timetuple().tm_yday,
+        "stop_year": end_date.year,
+        "stop_day": end_date.timetuple().tm_yday,
+        # Determines which equinox epoch to use. This corresponds to which instantaneous "First Point of Aries" (FPA) direction is used to specify longitude
+        # 2 corresponds to Mean-of-Date which is a smoothed FPA at 00.00 on date of interest
+        "equinox": "2",
+    }
+
+    # Get the data from HELIOWeb
+    response = requests.post(
+        "https://omniweb.gsfc.nasa.gov/cgi/models/helios2_h.cgi", data=query
+    )
+    # Raises an error on any non 2XX status code
+    response.raise_for_status()
+
+    # Extract the table from the html
+    text = response.text
+    match = re.search(r"<pre>(.*?)</pre>", text, flags=re.DOTALL)
+    if not match:
+        raise ValueError(
+            f"The response from HELIOWeb for {object_name} did not match as expected."
+        )
+    table_text = match.group(1)
+
+    # Convert the table text into a list of tuples which can then be converted into a np array
+    rows = []
+    for line in table_text.splitlines():
+        # Each line should just be whitespace separated text
+        cols = line.split()
+        # Skip the table header
+        if cols[0] == "YEAR":
+            continue
+
+        if len(cols) != 6 or not cols[0].isdigit():
+            print(line)
+            print(
+                f"Warning: malformed line in downloaded HELIOWeb data for {object_name}. See above output for details. Continuing..."
+            )
+
+        rows.append(tuple(cols))
+
+    output = np.array(
+        rows,
+        dtype=[
+            ("year", "i4"),
+            ("day", "i4"),
+            ("hour", "i4"),
+            ("radius_au", "f8"),
+            ("hgi_lat", "f8"),
+            ("hgi_lon", "f8"),
+        ],
+    )
+
+    return output
+
+
+def hgi_to_hnm_from_date(year, day_of_year, hour, r_hgi, lat_hgi, lon_hgi):
+    """Convert HGI Spherical coordinates to HNM spherical"""
+    jd = julian_date(year, day_of_year, hour)
+
+    lambda_angle = lambda_from_julian_date(jd)
+    omega_angle = omega_from_julian_date(jd)
+
+    rotation_angle = lambda_angle - omega_angle
+
+    # shift by rotation angle for HGI -> HEEQ
+    lon_heeq = np.deg2rad(lon_hgi) - rotation_angle
+    # 180 degree shift for HEEQ -> HNM
+    lon_hnm = lon_heeq + np.pi
+    lon_hnm = normalize_radians(lon_hnm)
+
+    # Latitude defines 90 degrees as the +Z axis and -90 as the -Z axis
+    # Co-latitude defines 0 degrees as the +Z axis and 180 as the -Z axis
+    # The coordinate system for ENLIL uses colatitude so we convert
+    colat_hnm = normalize_radians(-(np.deg2rad(lat_hgi) - np.pi / 2))
+
+    # There are a few differences between the outputted numpy array and the ENLIL .nc files
+    # The ENLIL .nc files have time measured in seconds relative to rundate_cal
+    # The ENLIL .nc files use radius in meters
+    data = np.array(
+        list(zip(year, day_of_year, hour, r_hgi, colat_hnm, lon_hnm)),
+        dtype=[
+            (
+                "year",
+                "i4",
+            ),
+            ("day", "i4"),
+            ("hour", "i4"),
+            ("radius_au", "f8"),
+            ("colattitude_rad", "f8"),
+            ("longitude_rad", "f8"),
+        ],
+    )
+    return data
+
+
+def t0_from_julian_date(jd):
+    """t0 is Julian centuries from J2000.0."""
+    return (np.asarray(jd) - J2000_JD) / JULIAN_CENTURY_DAYS
+
+
+def lambda_from_julian_date(jd):
+    """
+    Approximate heliocentric ecliptic longitude of Earth at J2000.
+
+    This uses the standard low-precision solar ephemeris: calculate the Sun's
+    true geocentric ecliptic longitude, then add 180 degrees for Earth's
+    heliocentric longitude. The result is relative to the ecliptic of date.
+    """
+    # Number of centuries since J2000
+    t0 = t0_from_julian_date(jd)
+    # Mean geometric geocentric ecliptic longitude of the sun.
+    # Geometric, as opposed to apparent, refers to the Sun's physical location and not the location in the sky with the effects of our atmosphere
+    # Source of equation: 'Geom Mean Long Sun' https://gml.noaa.gov/grad/solcalc/NOAA_Solar_Calculations_day.xls
+    mean_longitude = 280.46646 + 36000.76983 * t0 + 0.0003032 * t0**2
+    # Mean anomaly is the fraction of Earth's idealized circular orbit that has elapsed from the perihelion
+    # expressed as an angle for a given time. The first term, 357.52911, is the Earth's
+    # mean anomaly at J2000. Earth advances 359.990503° in mean anomaly during one Julian year (365.25 days),
+    # measured relative to the moving perihelion direction and is called the mean anomaly rate which
+    # is an angular velocity. Although this mean anomaly rate is assumed to be fixed for a given year,
+    # it drifts with time due to a variety of effects.
+    # Source of equation: 'Geom Mean Anom Sun' https://gml.noaa.gov/grad/solcalc/NOAA_Solar_Calculations_day.xls
+    mean_anomaly = np.deg2rad(357.52911 + 35999.05029 * t0 - 0.0001537 * t0**2)
+    # Equation of the center is the correction needed from mean anomaly to true anomaly.
+    # In other words it is the difference between the true anomaly and the mean anomaly.
+    # Because the earth is a low-ecentricity orbit that varies over time, we can model
+    # it with a time varrying sine series.
+    # We should expect the equation_of_center to be 0 at the perihelion and apehelion
+    # As the mean anomaly and true anomaly orbits intersect at these points. This correction for the Earth
+    # should max out at around 2 degrees for a given time.
+    # Source of equation: 'Sun Eq of Ctr' https://gml.noaa.gov/grad/solcalc/NOAA_Solar_Calculations_day.xls
+    equation_of_center = (
+        (1.914602 - 0.004817 * t0 - 0.000014 * t0**2) * np.sin(mean_anomaly)
+        + (0.019993 - 0.000101 * t0) * np.sin(2.0 * mean_anomaly)
+        + 0.000289 * np.sin(3.0 * mean_anomaly)
+    )
+    # Get the true heliocentric ecliptic longitude of the earth by
+    # appplying the correction, equation of the center, to the mean geocentric ecliptic longitude of the sun
+    # and apply a 180 degree rotation to get the mean heliocentric ecliptic longitude of the earth.
+    # This is just a rotation about the Z-axis, solar rotation axis to face the Earth rather than the Sun.
+    # We just need to add the equation of the center (difference between the mean anomaly and true anomaly):
+    # equation_of_center = true_anomaly - mean_anomaly
+    # true_anomaly = equation_of_center + mean_anomaly
+    # Lmean = Lperihelion + mean_anomaly
+    # Ltrue = Lperihilion + true_anomaly
+    # Ltrue = Lperihilion + mean_anomaly + equation_of_center
+    # Ltrue = Lmean + equation_of_center
+    # Source of equation: 'Sun True Long' https://gml.noaa.gov/grad/solcalc/NOAA_Solar_Calculations_day.xls
+    lambda_angle = mean_longitude + equation_of_center + 180.0
+    return np.deg2rad(lambda_angle)
+
+
+def julian_date(year, day_of_year, hour=0.0):
+    """
+    Convert year, day-of-year, and decimal hour to Julian Date.
+
+    Inputs may be scalars or array-like values. Day-of-year is one-indexed,
+    matching the values in the HGI .lst files.
+    """
+    year_arr, day_arr, hour_arr = np.broadcast_arrays(year, day_of_year, hour)
+
+    def scalar_julian_date(y, d, h):
+        start = datetime(int(y), 1, 1, tzinfo=timezone.utc)
+        dt = start + timedelta(days=float(d) - 1.0, hours=float(h))
+        unix_days = dt.timestamp() / 86400.0
+        return 2440587.5 + unix_days
+
+    if year_arr.shape == ():
+        return scalar_julian_date(year_arr.item(), day_arr.item(), hour_arr.item())
+
+    vectorized = np.vectorize(scalar_julian_date, otypes=[float])
+    return vectorized(year_arr, day_arr, hour_arr)
+
+
+def omega_from_julian_date(jd):
+    """
+    Longitude of the ascending node of the solar equator.
+    Curl your right hand in the direction of earth's orbit (counter clockwise)
+    and the ascending node is where the ecliptic
+
+    The traditional definition is relative to the ecliptic plane of date:
+    Omega = 75.76 deg + 1.397 deg * T0.
+    """
+    t0 = t0_from_julian_date(jd)
+    omega = 75.76 + 1.397 * np.asarray(t0)
+
+    return np.deg2rad(omega)
+
+
+def hnm_to_paraview(year, day_of_year, hour, r, colat, lon):
+    # Do a standard spherical to cartesian conversion
+    x = r * np.sin(colat) * np.cos(lon)
+    y = r * np.sin(colat) * np.sin(lon)
+    z = r * np.cos(colat)
+
+    # Convert year, day_of_year, hour to seconds since 1970-01-01
+    times = np.array(
+        [
+            (
+                datetime(int(year), 1, 1)
+                + timedelta(days=int(day) - 1, hours=int(hour))
+            ).timestamp()
+            for year, day, hour in zip(year, day_of_year, hour)
+        ]
+    )
+
+    data = np.asarray(
+        list(zip(x, y, z, times)),
+        dtype=[("X", "f8"), ("Y", "f8"), ("Z", "f8"), ("time", "i4")],
+    )
+
+    return data
+
+
+def build_pv_evo_dataset(x, y, z, t):
+
+    shape = len(t)
+    nan = np.full(shape, np.nan, dtype=np.float64)
+    nanf = np.full(shape, np.nan, dtype=np.float32)
+
+    # The decision to use nan/nanf was determined by
+    # looking at the datatypes in the processed evo.earth.nc
+    # using `ncdump -h <path-to-processed-evo-earth-nc>`
+    ds = xr.Dataset(
+        data_vars={
+            "X": xr.Variable("time", x, attrs={"units": "AU"}),
+            "Y": xr.Variable("time", y, attrs={"units": "AU"}),
+            "Z": xr.Variable("time", z, attrs={"units": "AU"}),
+            "Density": xr.Variable("time", nan),
+            "T": xr.Variable(
+                "time", nanf, attrs={"units": "K", "long_name": "Temperature"}
+            ),
+            # The current pv-evo datasets don't do a great job of defining these fields so not adding additional
+            # attrs for now
+            # TODO explore these more and provide proper units + descriptions
+            "DP": xr.Variable("time", nanf),
+            "Bx": xr.Variable("time", nanf),
+            "By": xr.Variable("time", nanf),
+            "Bz": xr.Variable("time", nanf),
+            "Br": xr.Variable("time", nanf),
+            "Vr": xr.Variable("time", nanf),
+            "Pressure": xr.Variable("time", nan),
+        },
+        coords={
+            "time": xr.Variable(
+                "time",
+                t,
+                attrs={
+                    "units": "seconds since 1970-01-01",
+                    "calendar": "proleptic_gregorian",
+                },
+            )
+        },
+    )
+
+    return ds
+
+
+def normalize_radians(angle):
+    """Normalize angle(s) to [0, 2*pi) radians."""
+    return np.mod(angle, 2.0 * np.pi)

--- a/scripts/process_output.py
+++ b/scripts/process_output.py
@@ -170,7 +170,7 @@ def process_evo(ds):
 
     ds = ds.rename(name_map)
     rad = ds["X1"] / AU
-    # TODO This conversion from colat/zenith angle -> elevation angle is probably unecessary
+    # TODO This conversion from colat/zenith angle -> elevation angle is probably unnecessary
     # since we don't use the 'lat' variable anywhere else
     lat = np.pi / 2 - ds["X2"]
     # subtract pi to point towards Earth
@@ -343,12 +343,14 @@ def process_directory(
     print(f"Evo files processed: {time.time() - t0} s")
 
     if helioweb_objects:
-        print("Processing helioweb objects.")
+        t0 = time.time()
+        print("Processing HelioWeb objects.")
 
         start_datetime = tim_datetime(tim_fnames[0])
         end_datetime = tim_datetime(tim_fnames[-1])
 
         process_helioweb(helioweb_objects, start_datetime, end_datetime, newpath)
+        print(f"HelioWeb objects processed: {time.time() - t0} s")
 
     if download_images:
         # Downloading images now, we want to download for every day in the dataset
@@ -580,6 +582,14 @@ def main():
     path = args.path
     if not path.exists() or not path.is_dir():
         raise ValueError(f"Provided path {path} is not a directory")
+
+    if not all(
+        helioweb_object in HELIOWEB_OBJECT_CODES.keys()
+        for helioweb_object in args.helioweb_objects
+    ):
+        raise ValueError(
+            f"One or more helioweb objects provided does not exist in HELIOWEB_OBJECT_CODES. Available values are {HELIOWEB_OBJECT_CODES.keys()!s}"
+        )
 
     process_directory(
         path,

--- a/scripts/process_output.py
+++ b/scripts/process_output.py
@@ -1,17 +1,16 @@
-from datetime import datetime, timedelta
+import argparse
 import hashlib
 import json
 import pathlib
-import sys
+import re
 import time
 import urllib.request
 import warnings
-import re
-import argparse
-
+from datetime import datetime, timedelta
 
 import numpy as np
 import xarray as xr
+from process_helioweb import HELIOWEB_OBJECT_CODES, process_helioweb
 
 # Earth to Sun distance (m)
 AU = 1.496e11
@@ -171,6 +170,8 @@ def process_evo(ds):
 
     ds = ds.rename(name_map)
     rad = ds["X1"] / AU
+    # TODO This conversion from colat/zenith angle -> elevation angle is probably unecessary
+    # since we don't use the 'lat' variable anywhere else
     lat = np.pi / 2 - ds["X2"]
     # subtract pi to point towards Earth
     lon = ds["X3"]
@@ -217,7 +218,17 @@ def process_evo(ds):
 
     return ds
 
-def process_directory(path, download_images=False, radius_downsample=1, longitude_downsample=1, latitude_downsample=1, aggregation="mean", boundary="trim"):
+
+def process_directory(
+    path: pathlib.Path,
+    download_images=False,
+    radius_downsample=1,
+    longitude_downsample=1,
+    latitude_downsample=1,
+    aggregation="mean",
+    boundary="trim",
+    helioweb_objects: list[str] = [],
+):
     """
     Processes the given directory to transform the files into
     suitable data for Paraview ingest.
@@ -238,6 +249,8 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
         Aggregation method to use for downsampling
     boundary : str (default "trim")
         Boundary handling method for downsampling
+    helioweb_objects : list[str] (default [])
+        List of helioweb objects to process
     """
     tim_fnames = sorted(path.glob("tim.*.nc"))
     if len(tim_fnames) == 0:
@@ -258,7 +271,15 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
     for i, fname in enumerate(tim_fnames):
         with xr.load_dataset(fname) as ds:
             # Apply downsampling using the specified aggregation method
-            ds = getattr(ds.coarsen(n1=radius_downsample, n2=latitude_downsample, n3=longitude_downsample, boundary=boundary), aggregation)()
+            ds = getattr(
+                ds.coarsen(
+                    n1=radius_downsample,
+                    n2=latitude_downsample,
+                    n3=longitude_downsample,
+                    boundary=boundary,
+                ),
+                aggregation,
+            )()
 
             # Process single file
             ds = process_tim(ds)
@@ -272,9 +293,11 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
                     cone_fname = cone_fnames[0]
                     cone_metadata = generate_cone_metadata_dict(cone_fname)
                     metadata = metadata | cone_metadata
-                else: 
-                    warnings.warn("No CONE file found so the following fields will not be present in metadata.json:" \
-                        " cme_longitude, cme_latitude, cme_time, cme_cone_half_angle, and cme_radial_velocity")
+                else:
+                    warnings.warn(
+                        "No CONE file found so the following fields will not be present in metadata.json:"
+                        " cme_longitude, cme_latitude, cme_time, cme_cone_half_angle, and cme_radial_velocity"
+                    )
 
                 # Save the metadata
                 newpath = path / f"pv-ready-data-{metadata['run_id']}"
@@ -289,7 +312,7 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
                 newpath / f"pv-{fname.name}",
                 encoding={"time": {"units": "seconds since 1970-01-01"}},
             )
-    print(f"TIM files processed: {time.time()-t0} s")
+    print(f"TIM files processed: {time.time() - t0} s")
 
     print(f"Processing {len(evo_fnames)} EVO files")
     for fname in evo_fnames:
@@ -317,7 +340,15 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
                         )
                     )
                 )
-    print(f"Evo files processed: {time.time()-t0} s")
+    print(f"Evo files processed: {time.time() - t0} s")
+
+    if helioweb_objects:
+        print("Processing helioweb objects.")
+
+        start_datetime = tim_datetime(tim_fnames[0])
+        end_datetime = tim_datetime(tim_fnames[-1])
+
+        process_helioweb(helioweb_objects, start_datetime, end_datetime, newpath)
 
     if download_images:
         # Downloading images now, we want to download for every day in the dataset
@@ -331,7 +362,7 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
             download_hmi(curr_date, outdir=str(newpath) + "/solar_images")
             curr_date += dt
 
-        print(f"Images saved: {time.time()-t0} s")
+        print(f"Images saved: {time.time() - t0} s")
 
 
 def process_metadata(ds, path=None, run_id=None):
@@ -352,8 +383,8 @@ def process_metadata(ds, path=None, run_id=None):
     """
     s = json.dumps(ds.attrs, cls=NumpyEncoder)
     # Hash based on the metadata of the run
-    hash_digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]    
-    ds = ds.assign_attrs(hash_digest=hash_digest) 
+    hash_digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]
+    ds = ds.assign_attrs(hash_digest=hash_digest)
     # Determine the institute based on the project name
     project = ds.attrs.get("project", "")
     if project.startswith("a8b1"):
@@ -370,13 +401,15 @@ def process_metadata(ds, path=None, run_id=None):
     # Extract the run_id from the dataset attributes
     if not run_id:
         # In order to extract the run_id from a SWPC run, the path must end with wsa_enlil_57484.57285344.dbqs0
-        if institute == "SWPC" and re.match(r"^.*wsa_enlil_\d{5}\.\d*\.dbqs0", path.name):
+        if institute == "SWPC" and re.match(
+            r"^.*wsa_enlil_\d{5}\.\d*\.dbqs0", path.name
+        ):
             run_id = path.name.split("_")[-1].split(".")[0]
         else:
             run_id = hash_digest
-        
+
     ds = ds.assign_attrs(run_id=run_id)
-        
+
     return ds.attrs
 
 
@@ -457,7 +490,7 @@ def generate_cone_metadata_dict(cone_fname):
     dict
         Dictionary containing fields of interest from cone file
     """
-    
+
     with open(cone_fname, "r", encoding="utf-8") as cone_file:
         cone_text = cone_file.read()
 
@@ -465,7 +498,7 @@ def generate_cone_metadata_dict(cone_fname):
     data = {}
     for line in cone_text.splitlines():
         # Clear whitespace and remove trailing commas
-        line = line.strip().rstrip(',')
+        line = line.strip().rstrip(",")
         if line.startswith("lon="):
             data["cme_longitude"] = line.split("=")[1]
         elif line.startswith("ldates="):
@@ -480,6 +513,12 @@ def generate_cone_metadata_dict(cone_fname):
     return data
 
 
+def tim_datetime(path):
+    with xr.open_dataset(path, decode_times=False) as ds:
+        run_start = datetime.strptime(ds.attrs["rundate_cal"], "%Y-%m-%dT%H")
+        return run_start + timedelta(seconds=float(ds["TIME"].item()))
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="H3lioviz Enlil Output Processor",
@@ -487,7 +526,7 @@ def main():
     )
     parser.add_argument(
         "path",
-        type=str,
+        type=pathlib.Path,
         help="Path to the directory containing Enlil .nc files to process.",
     )
     parser.add_argument(
@@ -520,18 +559,37 @@ def main():
         type=str,
         choices=["trim", "pad", "exact"],
         default="trim",
-        help="How to handle boundaries during coarsening. Default is trim."
+        help="How to handle boundaries during coarsening. Default is trim.",
     )
+    parser.add_argument(
+        "--helioweb-objects",
+        type=lambda x: x.split(","),
+        default=[],
+        help=f"A list of helioweb objects you would like processed evo files for. Allowable values include {list(HELIOWEB_OBJECT_CODES.keys())!s}",
+    )
+
     args = parser.parse_args()
 
-    if args.radius_downsample < 1 or args.longitude_downsample < 1 or args.latitude_downsample < 1:
+    if (
+        args.radius_downsample < 1
+        or args.longitude_downsample < 1
+        or args.latitude_downsample < 1
+    ):
         raise ValueError("Downsampling factors must be greater than or equal to 1.")
 
-    path = pathlib.Path(args.path)
+    path = args.path
     if not path.exists() or not path.is_dir():
         raise ValueError(f"Provided path {path} is not a directory")
-    
-    process_directory(path, radius_downsample=args.radius_downsample, longitude_downsample=args.longitude_downsample, latitude_downsample=args.latitude_downsample, boundary=args.boundary, aggregation=args.aggregation)
+
+    process_directory(
+        path,
+        radius_downsample=args.radius_downsample,
+        longitude_downsample=args.longitude_downsample,
+        latitude_downsample=args.latitude_downsample,
+        boundary=args.boundary,
+        aggregation=args.aggregation,
+        helioweb_objects=args.helioweb_objects,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,3 +4,6 @@ numpy
 scipy
 xarray
 importlib-metadata==4.13.0
+
+# Additional dependencies for helioweb
+requests


### PR DESCRIPTION
This was not done as a part of my official work at LASP. As a result, there is no rush to get this reviewed nor merged as I can keep developing on my fork if I choose. 

Added functionality to the processing that allows for helioweb objecs to be added. In particular the inner planets, but some satellites will be available as well. This is purely optional and is enabled with a flag. 

Available objects are [here](https://omniweb.gsfc.nasa.gov/coho/helios/heli.html). Additional object codes would need to be added to the HELIOWEB_OBJECT_CODEES in process_helioweb. I found codes that are currently available by making a request to the website for a dataset and inspecting the request. 

Run 58279 is a good one to test with as I have the met offices 2D version for June 16th at 1:00. The visualization you see is from the draft-inner-visualization branch available in this repository. I want to flush out the way these satellites are handled a little more in a separate PR. I am deployed locally and using a version of the front end that utilizes the dev API. 

<img width="1181" height="1094" alt="image" src="https://github.com/user-attachments/assets/3cb5ad95-d4f1-4517-9231-f3d18b58cd4a" />

<img width="874" height="663" alt="image" src="https://github.com/user-attachments/assets/16401e50-1544-4305-b61d-09f02c2e5a4b" />
