### PR TITLE
Create migration script for old runs (DB-3623)

### DIFF
--- a/scripts/migrate_run.py
+++ b/scripts/migrate_run.py
@@ -1,0 +1,124 @@
+# Purpose: This script was developed because we no longer have the original data
+#          for some runs and therefore need to apply updates to runs that have
+#          already gone through some processing.
+#
+# Note: This script does not update metadata.json for the v0.0.0 -> v1.1.1 migration
+#       besides updating/adding h3lioviz_processing_version. This is done because some
+#       data in metadata.json for old runs appears to have been added manually (like the institute)
+#
+import argparse
+import json
+import logging
+import shutil
+from pathlib import Path
+from datetime import datetime
+
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+
+def migrate_run_v0_to_v1(path: Path):
+    # This is intended to fail if the path already exists to prevent overwriting
+    output_path = Path(f"{path!s}-migrated")
+    output_path.mkdir()
+
+    tim_paths = path.glob("pv-tim.*.nc")
+    for tim_path in tim_paths:
+        with xr.load_dataset(tim_path) as ds:
+            ds = migrate_tim_v0_to_v1(ds)
+
+            ds.to_netcdf(
+                output_path / tim_path.name,
+                encoding={"time": {"units": "seconds since 1970-01-01"}},
+            )
+
+    evo_paths = path.glob("evo.*.nc")
+    for evo_path in evo_paths:
+        new_path = output_path / evo_path.name
+        with xr.load_dataset(evo_path) as ds:
+            ds = migrate_evo_v0_to_v1(ds)
+
+            ds.to_netcdf(
+                new_path,
+                encoding={"time": {"units": "seconds since 1970-01-01"}},
+            )
+
+        with xr.load_dataset(new_path) as ds:
+            json_file = Path(str(new_path).replace(".nc", ".json"))
+
+            # Save the json file in the same way as process_output.py
+            with open(json_file, "w") as fp:
+                fp.write(
+                    json.dumps(
+                        json.loads(
+                            json.dumps(ds.to_dict(), default=serialize_datetime),
+                            parse_float=lambda x: round(float(x), 3),
+                        )
+                    )
+                )
+
+    # Add/update h3lioviz_processing_version in metadata.json
+    with open(path / "metadata.json", "r") as fp:
+        metadata = json.load(fp)
+        metadata["h3lioviz_processing_version"] = "1.0.0"
+    with open(output_path / "metadata.json", "w") as fp:
+        json.dump(metadata, fp)
+
+    # Copy the cone file unmodified if it exists
+    cone_file_path = next(path.glob("cone2bc.in.*"), None)
+    if cone_file_path:
+        shutil.copyfile(cone_file_path, output_path / cone_file_path.name)
+
+
+def migrate_tim_v0_to_v1(ds: xr.Dataset):
+    # Updated as a part of "DB-3308" PR Oct. 24, 2025
+    ds["Pressure"] = ds["Pressure"] / 1e6
+    ds["Pressure"].attrs.update({"units": "r^2 * N / m^3 * km^2 / s^2"})
+
+    # Updates as a part of "Multiply Br by normalized radius squared" PR on Oct. 21, 2025
+    ds["Br"] *= ds["radius"] ** 2
+
+    return ds
+
+
+# Note that the Br = B1 is the only thing updated. However during normal processing B1 is
+# dropped so the odds that any of the evo files are updated are low for this migration.
+def migrate_evo_v0_to_v1(ds: xr.Dataset):
+    # Updated as a part of "Added Br to evo" PR on Oct. 13, 2025
+    if "B1" in ds:
+        ds["Br"] = ds["B1"]
+    else:
+        logger.warning("Variable B1 does not exist in dataset.")
+
+    return ds
+
+
+def serialize_datetime(obj):
+    if isinstance(obj, datetime):
+        return obj.timestamp()
+    else:
+        return obj
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="Migrate H3lioviz Run")
+
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to the directory containing .nc files that need migration.",
+    )
+
+    args = parser.parse_args()
+
+    if not args.path.exists() or args.path.is_file():
+        raise ValueError(
+            f"Provided path '{args.path!s}' does not exist or is not a directory."
+        )
+
+    migrate_run_v0_to_v1(args.path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_run.py
+++ b/scripts/migrate_run.py
@@ -36,13 +36,10 @@ def migrate_run_v0_to_v1(path: Path):
     evo_paths = path.glob("evo.*.nc")
     for evo_path in evo_paths:
         new_path = output_path / evo_path.name
-        with xr.load_dataset(evo_path) as ds:
+        with xr.load_dataset(evo_path, decode_times=False) as ds:
             ds = migrate_evo_v0_to_v1(ds)
 
-            ds.to_netcdf(
-                new_path,
-                encoding={"time": {"units": "seconds since 1970-01-01"}},
-            )
+            ds.to_netcdf(new_path)
 
         with xr.load_dataset(new_path) as ds:
             json_file = Path(str(new_path).replace(".nc", ".json"))

--- a/scripts/process_output.py
+++ b/scripts/process_output.py
@@ -23,6 +23,8 @@ m3_to_cm3 = (1.0 / 100) ** 3
 density_conversion = 1.0 / m_hydrogen * m3_to_cm3
 # m/s -> km/s
 velocity_conversion = 1.0 / 1000.0
+# Used to identify what processing code created the processed run
+H3LIOVIZ_PROCESSING_VERSION = "1.0.0"
 
 
 class NumpyEncoder(json.JSONEncoder):
@@ -217,7 +219,16 @@ def process_evo(ds):
 
     return ds
 
-def process_directory(path, download_images=False, radius_downsample=1, longitude_downsample=1, latitude_downsample=1, aggregation="mean", boundary="trim"):
+
+def process_directory(
+    path,
+    download_images=False,
+    radius_downsample=1,
+    longitude_downsample=1,
+    latitude_downsample=1,
+    aggregation="mean",
+    boundary="trim",
+):
     """
     Processes the given directory to transform the files into
     suitable data for Paraview ingest.
@@ -258,7 +269,15 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
     for i, fname in enumerate(tim_fnames):
         with xr.load_dataset(fname) as ds:
             # Apply downsampling using the specified aggregation method
-            ds = getattr(ds.coarsen(n1=radius_downsample, n2=latitude_downsample, n3=longitude_downsample, boundary=boundary), aggregation)()
+            ds = getattr(
+                ds.coarsen(
+                    n1=radius_downsample,
+                    n2=latitude_downsample,
+                    n3=longitude_downsample,
+                    boundary=boundary,
+                ),
+                aggregation,
+            )()
 
             # Process single file
             ds = process_tim(ds)
@@ -272,9 +291,11 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
                     cone_fname = cone_fnames[0]
                     cone_metadata = generate_cone_metadata_dict(cone_fname)
                     metadata = metadata | cone_metadata
-                else: 
-                    warnings.warn("No CONE file found so the following fields will not be present in metadata.json:" \
-                        " cme_longitude, cme_latitude, cme_time, cme_cone_half_angle, and cme_radial_velocity")
+                else:
+                    warnings.warn(
+                        "No CONE file found so the following fields will not be present in metadata.json:"
+                        " cme_longitude, cme_latitude, cme_time, cme_cone_half_angle, and cme_radial_velocity"
+                    )
 
                 # Save the metadata
                 newpath = path / f"pv-ready-data-{metadata['run_id']}"
@@ -289,7 +310,7 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
                 newpath / f"pv-{fname.name}",
                 encoding={"time": {"units": "seconds since 1970-01-01"}},
             )
-    print(f"TIM files processed: {time.time()-t0} s")
+    print(f"TIM files processed: {time.time() - t0} s")
 
     print(f"Processing {len(evo_fnames)} EVO files")
     for fname in evo_fnames:
@@ -317,7 +338,7 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
                         )
                     )
                 )
-    print(f"Evo files processed: {time.time()-t0} s")
+    print(f"Evo files processed: {time.time() - t0} s")
 
     if download_images:
         # Downloading images now, we want to download for every day in the dataset
@@ -331,7 +352,7 @@ def process_directory(path, download_images=False, radius_downsample=1, longitud
             download_hmi(curr_date, outdir=str(newpath) + "/solar_images")
             curr_date += dt
 
-        print(f"Images saved: {time.time()-t0} s")
+        print(f"Images saved: {time.time() - t0} s")
 
 
 def process_metadata(ds, path=None, run_id=None):
@@ -352,8 +373,8 @@ def process_metadata(ds, path=None, run_id=None):
     """
     s = json.dumps(ds.attrs, cls=NumpyEncoder)
     # Hash based on the metadata of the run
-    hash_digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]    
-    ds = ds.assign_attrs(hash_digest=hash_digest) 
+    hash_digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]
+    ds = ds.assign_attrs(hash_digest=hash_digest)
     # Determine the institute based on the project name
     project = ds.attrs.get("project", "")
     if project.startswith("a8b1"):
@@ -370,13 +391,17 @@ def process_metadata(ds, path=None, run_id=None):
     # Extract the run_id from the dataset attributes
     if not run_id:
         # In order to extract the run_id from a SWPC run, the path must end with wsa_enlil_57484.57285344.dbqs0
-        if institute == "SWPC" and re.match(r"^.*wsa_enlil_\d{5}\.\d*\.dbqs0", path.name):
+        if institute == "SWPC" and re.match(
+            r"^.*wsa_enlil_\d{5}\.\d*\.dbqs0", path.name
+        ):
             run_id = path.name.split("_")[-1].split(".")[0]
         else:
             run_id = hash_digest
-        
+
     ds = ds.assign_attrs(run_id=run_id)
-        
+
+    ds = ds.assign_attrs(h3lioviz_processing_version=H3LIOVIZ_PROCESSING_VERSION)
+
     return ds.attrs
 
 
@@ -457,7 +482,7 @@ def generate_cone_metadata_dict(cone_fname):
     dict
         Dictionary containing fields of interest from cone file
     """
-    
+
     with open(cone_fname, "r", encoding="utf-8") as cone_file:
         cone_text = cone_file.read()
 
@@ -465,7 +490,7 @@ def generate_cone_metadata_dict(cone_fname):
     data = {}
     for line in cone_text.splitlines():
         # Clear whitespace and remove trailing commas
-        line = line.strip().rstrip(',')
+        line = line.strip().rstrip(",")
         if line.startswith("lon="):
             data["cme_longitude"] = line.split("=")[1]
         elif line.startswith("ldates="):
@@ -520,18 +545,29 @@ def main():
         type=str,
         choices=["trim", "pad", "exact"],
         default="trim",
-        help="How to handle boundaries during coarsening. Default is trim."
+        help="How to handle boundaries during coarsening. Default is trim.",
     )
     args = parser.parse_args()
 
-    if args.radius_downsample < 1 or args.longitude_downsample < 1 or args.latitude_downsample < 1:
+    if (
+        args.radius_downsample < 1
+        or args.longitude_downsample < 1
+        or args.latitude_downsample < 1
+    ):
         raise ValueError("Downsampling factors must be greater than or equal to 1.")
 
     path = pathlib.Path(args.path)
     if not path.exists() or not path.is_dir():
         raise ValueError(f"Provided path {path} is not a directory")
-    
-    process_directory(path, radius_downsample=args.radius_downsample, longitude_downsample=args.longitude_downsample, latitude_downsample=args.latitude_downsample, boundary=args.boundary, aggregation=args.aggregation)
+
+    process_directory(
+        path,
+        radius_downsample=args.radius_downsample,
+        longitude_downsample=args.longitude_downsample,
+        latitude_downsample=args.latitude_downsample,
+        boundary=args.boundary,
+        aggregation=args.aggregation,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Note: The only meaningful update to `process_output.py` is on line 403: `ds = ds.assign_attrs(h3lioviz_processing_version=H3LIOVIZ_PROCESSING_VERSION)`
and in the beginning of the file with `H3LIOVIZ_PROCESSING_VERSION`
The rest is just formatter updates. 

# Purpose

There are some old runs with alphanumeric run ids that are so old they do not exist in NOAAs S3 and thus we cannot reprocess them using the reingest lambda. Therefore, we need a script that can take already processed runs and update them with the current processing.

# Testing

1. Log in to dev to download the run 

```
assume
s5cmd cp s3://h3lioviz.dev.swx-trec.com/data/h3lioviz/pv-ready-data-bd15cd93/\* ./pv-ready-data-bd15cd93
```

2. Run the migration script

```
cd scripts
python3 -m venv venv
source venv/bin/activate
python3 -r requirements.txt
python3 migrate_run.py ../pv-ready-data-bd15cd93
```

3. Upload that data to **legacy**

```
assume
s5cmd cp ./pv-ready-data-bd15cd93-migrated/\* s3://h3lioviz.robertdev.swx-trec.com/data/h3lioviz/pv-ready-data-bd15cd93/
```

4. Update the metadata table by running the sync metadata lambda. If this doesn't update the table, DB-3623 in swxtrec-cdk needs to be deployed. 

5. Go to https://h3lioviz.robertdev.swx-trec.com/h3lioviz and verify that the run is working. The `bd15cd93old` run shows you how it looks before a migration 

# Merge Steps

After merging we should identify all the runs we would like to migrate. I know bd1l5cd93 is one of them. 

1. Identify runs to migrate
2. Download runs to migrate
3. Run migration script on runs
4. Take backup of the runs to migrate in s3 for archival purposes
5. Upload the migrated runs (which will overwrite the original data)